### PR TITLE
[Issue #61] Minor enhancements, fixed some typos

### DIFF
--- a/03-setup-ingress-ambassador/README.md
+++ b/03-setup-ingress-ambassador/README.md
@@ -37,9 +37,9 @@ After finishing this tutorial, you will be able to:
 - [Step 7 - Enabling Proxy Protocol](#step-7---enabling-proxy-protocol)
 - [Step 8 - Verifying the Ambassador Edge Stack Setup](#step-8---verifying-the-ambassador-edge-stack-setup)
 - [How To Guides](#how-to-guides)
-    - [Wildcard Certificates Support for the Ambassador Edge Stack](guides/wildcard_certificates.md)
-    - [Migrating DigitalOcean LoadBalancer for the Ambassador Edge Stack](guides/do_loadbalancer_migration.md)
-    - [Performance Considerations for the Ambassador Edge Stack](guides/performance_considerations.md)
+  - [Wildcard Certificates Support for the Ambassador Edge Stack](guides/wildcard_certificates.md)
+  - [Migrating DigitalOcean LoadBalancer for the Ambassador Edge Stack](guides/do_loadbalancer_migration.md)
+  - [Performance Considerations for the Ambassador Edge Stack](guides/performance_considerations.md)
 - [Conclusion](#conclusion)
 
 ## Prerequisites


### PR DESCRIPTION
## Overview

- Use the `LoadBalancer` term only when referring to the Kubernetes service.
- Use a better title for the load balancer migration section of the guide.
- Fixed some typos.