### PR TITLE
Update `..-proxy-protocol` from `true` to `"true"`

### DIFF
--- a/03-setup-ingress-controller/nginx.md
+++ b/03-setup-ingress-controller/nginx.md
@@ -747,7 +747,7 @@ service:
  type: LoadBalancer
  annotations:
    # Enable proxy protocol
-   service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: true
+   service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
 ```
 
 **Note:**


### PR DESCRIPTION
From the docs:
> You have to supply the value as string (ex. "true", not true), otherwise you might run into a k8s bug that throws away all annotations on your Service resource.

https://github.com/kubernetes/kubernetes/issues/59113

I'm not sure if this is correct, since it still does not fixes my problems, but it seems to be a discrepancy between the docs and the starter-kit.