### PR TITLE
fix: configmap name for loki

### DIFF
--- a/04-setup-observability/loki-stack.md
+++ b/04-setup-observability/loki-stack.md
@@ -267,7 +267,7 @@ This is great, but how does Promtail discover `Kubernetes` pods and assigns labe
 The `scrape_configs` section from the `Promtail` main `configuration` will show you the details. You can use `kubectl` for inspection (notice that the application `configuration` is stored using a `Kubernetes ConfigMap`):
 
 ```shell
-kubectl get cm loki-stack -n loki-stack -o yaml > loki-promtail-config.yaml
+kubectl get cm loki-loki-stack -n loki-stack -o yaml > loki-promtail-config.yaml
 ```
 
 Next, please open the `loki-promtail-config.yaml` file using a text editor of your choice (preferably with `YAML` support). For example you can use [VS Code](https://code.visualstudio.com):


### PR DESCRIPTION
Guess there is a typo here 🐱 

```
╰─➤  k get cm -n loki-stack
NAME                   DATA   AGE
loki-loki-stack        1      5h13m
loki-loki-stack-test   1      5h13m
kube-root-ca.crt       1      5h13m
```