### PR TITLE
Fixed an issue with the start of the file resulting in an error

### DIFF
--- a/03-setup-ingress-controller/assets/manifests/ambassador/ambassador_listener.yaml
+++ b/03-setup-ingress-controller/assets/manifests/ambassador/ambassador_listener.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: getambassador.io/v3alpha1
 kind: Listener
 metadata:


### PR DESCRIPTION
The first line of "---" causes kubectl apply to return the error:

`error: no objects passed to apply`

due to the fact nothing comes before that --- and it reads that as an empty file.